### PR TITLE
Change timeout parameter to double

### DIFF
--- a/php5/memcache_session.c
+++ b/php5/memcache_session.c
@@ -73,7 +73,8 @@ PS_OPEN_FUNC(memcache)
 		}
 
 		if (i < j) {
-			int persistent = 0, udp_port = 0, weight = 1, timeout = MMC_DEFAULT_TIMEOUT, retry_interval = MMC_DEFAULT_RETRY;
+			int persistent = 0, udp_port = 0, weight = 1, retry_interval = MMC_DEFAULT_RETRY;
+			double timeout = MMC_DEFAULT_TIMEOUT;
 
 			/* translate unix: into file: */
 			if (!strncmp(save_path+i, "unix:", sizeof("unix:")-1)) {
@@ -121,8 +122,8 @@ PS_OPEN_FUNC(memcache)
 				}
 
 				if (zend_hash_find(Z_ARRVAL_P(params), "timeout", sizeof("timeout"), (void **) &param) != FAILURE) {
-					convert_to_long_ex(param);
-					timeout = Z_LVAL_PP(param);
+					convert_to_double_ex(param);
+					timeout = Z_DVAL_PP(param);
 				}
 
 				if (zend_hash_find(Z_ARRVAL_P(params), "retry_interval", sizeof("retry_interval"), (void **) &param) != FAILURE) {

--- a/php7/memcache_session.c
+++ b/php7/memcache_session.c
@@ -69,7 +69,8 @@ PS_OPEN_FUNC(memcache)
 		}
 
 		if (i < j) {
-			int persistent = 0, udp_port = 0, weight = 1, timeout = MMC_DEFAULT_TIMEOUT, retry_interval = MMC_DEFAULT_RETRY;
+			int persistent = 0, udp_port = 0, weight = 1, retry_interval = MMC_DEFAULT_RETRY;
+			double timeout = MMC_DEFAULT_TIMEOUT;
 
 			/* translate unix: into file: */
 			if (!strncmp(save_path+i, "unix:", sizeof("unix:")-1)) {
@@ -116,8 +117,8 @@ PS_OPEN_FUNC(memcache)
 				}
 
 				if ((param = zend_hash_str_find(Z_ARRVAL(params), "timeout", sizeof("timeout")-1)) != NULL) {
-					convert_to_long_ex(param);
-					timeout = Z_LVAL_P(param);
+					convert_to_double_ex(param);
+					timeout = Z_DVAL_P(param);
 				}
 
 				if ((param = zend_hash_str_find(Z_ARRVAL(params), "retry_interval", sizeof("retry_interval")-1)) != NULL) {


### PR DESCRIPTION
Allow set timeout parameter in double values: **timeout=0.1**, this means timeout is 100ms.

[mmc_find_persistent](https://github.com/websupport-sk/pecl-memcache/blob/NON_BLOCKING_IO_php7/php5/memcache.c#L707)() and [mmc_server_new](https://github.com/websupport-sk/pecl-memcache/blob/NON_BLOCKING_IO_php7/php5/memcache_pool.c#L537)() timeout paramters are already in double type.