### PR TITLE
move connect to proper section to make SKIP work

### DIFF
--- a/tests/pecl16442.phpt
+++ b/tests/pecl16442.phpt
@@ -1,5 +1,7 @@
 --TEST--
 PECL bug #16442 (memcache_set fail with integer value)
+--SKIPIF--
+<?php include 'connect.inc'; ?>
 --FILE--
 <?php
 


### PR DESCRIPTION
otherwise this test will FAIL instead of SKIP if memcache server is not available