### PR TITLE
applying patch for php bug 73539

### DIFF
--- a/memcache_session.c
+++ b/memcache_session.c
@@ -75,7 +75,11 @@ PS_OPEN_FUNC(memcache)
 				efree(path);
 			}
 			else {
-				url = php_url_parse_ex(save_path+i, j-i);
+				//duplicate string as workaround to php bug 73539, affects php 5.6.28+
+				int len = j-i;
+				char *path = estrndup(save_path+i, len);
+				url = php_url_parse_ex(path, strlen(path));
+				efree(path);
 			}
 
 			if (!url) {


### PR DESCRIPTION
Ever since php 5.6.28 and php 7.0.13 was released, the internal workings of php_url_parse_ex() changed.  This was used by a few php extensions that used to parse multiple urls in a single string, including memcache and redis.  To trigger this bug you need to use memcache for sessions and have at least 2 memcache servers configured.  The bugs are posted https://bugs.php.net/bug.php?id=73539 and https://bugs.php.net/bug.php?id=73497 https://bugs.php.net/bug.php?id=73729