### PR TITLE
Fix func declaration for mmc_prepare_key_ex

### DIFF
--- a/php7/memcache_pool.h
+++ b/php7/memcache_pool.h
@@ -396,7 +396,7 @@ int mmc_unpack_value(mmc_t *, mmc_request_t *, mmc_buffer_t *, const char *, uns
 double timeval_to_double(struct timeval tv);
 struct timeval double_to_timeval(double sec);
 
-int mmc_prepare_key_ex(const char *, unsigned int, char *, unsigned int *);
+int mmc_prepare_key_ex(const char *, unsigned int, char *, unsigned int *, char *);
 int mmc_prepare_key(zval *, char *, unsigned int *);
 
 #define mmc_str_left(h, n, hlen, nlen) ((hlen) >= (nlen) ? memcmp((h), (n), (nlen)) == 0 : 0)


### PR DESCRIPTION
Declaration in header file was not reflecting an actual function and caused compilation error:
```
/pecl-memcache-NON_BLOCKING_IO_php7/php7/memcache.c: In function 'php_mmc_store':
/pecl-memcache-NON_BLOCKING_IO_php7/php7/memcache.c:643:8: error: too many arguments to function 'mmc_prepare_key_ex'
    if (mmc_prepare_key_ex(ZSTR_VAL(key), ZSTR_LEN(key), request->key, &(request->key_len), MEMCACHE_G(key_prefix)) != MMC_OK) {
        ^~~~~~~~~~~~~~~~~~
In file included from /pecl-memcache-NON_BLOCKING_IO_php7/php7/php_memcache.h:34:0,
                 from /pecl-memcache-NON_BLOCKING_IO_php7/php7/memcache.c:30:
/pecl-memcache-NON_BLOCKING_IO_php7/php7/memcache_pool.h:399:5: note: declared here
 int mmc_prepare_key_ex(const char *, unsigned int, char *, unsigned int *);
     ^~~~~~~~~~~~~~~~~~
```