### PR TITLE
allow to work with standard session.save_path option and session_save…

### DIFF
--- a/php7/memcache_session.c
+++ b/php7/memcache_session.c
@@ -56,7 +56,12 @@ PS_OPEN_FUNC(memcache)
 	zval params, *param;
 	int i, j, path_len;
 
-	char *path = MEMCACHE_G(session_save_path);
+	const char *path = MEMCACHE_G(session_save_path);
+	if (!path) {
+		/* allow to work with standard session.save_path option
+		   and session_save_path function */
+		path = save_path;
+	}
 	if (!path) {
 		PS_SET_MOD_DATA(NULL);
 		return FAILURE;
@@ -98,7 +103,6 @@ PS_OPEN_FUNC(memcache)
 			if (!url) {
 				php_error_docref(NULL, E_WARNING,
 					"Failed to parse memcache.save_path (error at offset %d, url was '%s')", i, path);
-				efree(path);
 
 				mmc_pool_free(pool);
 				PS_SET_MOD_DATA(NULL);

--- a/tests/036b.phpt
+++ b/tests/036b.phpt
@@ -1,0 +1,70 @@
+--TEST--
+ini_set('session.save_path')
+--SKIPIF--
+<?php include 'connect.inc'; if (!MEMCACHE_HAVE_SESSION) print 'skip not compiled with session support'; ?>
+--FILE--
+<?php
+
+include 'connect.inc';
+
+$session_save_path = "tcp://$host:$port?persistent=1&udp_port=0&weight=2&timeout=2&retry_interval=10,tcp://$host2:$port2";
+ini_set('session.save_handler', 'memcache');
+session_save_path($session_save_path);
+
+
+$result1 = session_start();
+$id = session_id();
+
+$_SESSION['_test_key'] = 'Test';
+
+$result2 = $memcache->get($id);
+session_write_close();
+$result3 = $memcache->get($id);
+
+// Test destroy
+$result4 = session_start();
+$result5 = session_destroy();
+$result6 = $memcache->get($id);
+
+// Test large session
+$session_save_path = "tcp://$host:$port";
+session_save_path($session_save_path);
+
+session_start();
+$largeval = str_repeat('a', 1024*2048);
+$_SESSION['_test_key']= $largeval;
+session_write_close();
+
+// test large cookie lifetime
+ini_set('session.gc_maxlifetime', 1209600);
+$result7 = session_start();
+$id = session_id();
+$_SESSION['_test_key'] = 'Test';
+$result8 = $memcache->get($id);
+session_write_close();
+$result9 = $memcache->get($id);
+
+
+var_dump($result1);
+var_dump($id);
+var_dump($result2);
+var_dump($result3);
+var_dump($result4);
+var_dump($result5);
+var_dump($result6);
+var_dump($result7);
+var_dump($result8);
+var_dump($result9);
+
+?>
+--EXPECTF--
+bool(true)
+string(%d) "%s"
+bool(false)
+string(%d) "%s"
+bool(true)
+bool(true)
+bool(false)
+bool(true)
+string(%d) "%s"
+string(%d) "%s"


### PR DESCRIPTION
…_path function


Testing on 4.0.2, I don't understand why `memcache.session_save_path` have been introduce, especially as session.save_path is probably enough, and this new option break configuration written for older version.

So, this trivial fix make it working again.
`session.save_path` is only used if  `memcache.session_save_path` is not set.