### PR TITLE
Use zend_bool for ini bool settings

### DIFF
--- a/php7/memcache.c
+++ b/php7/memcache.c
@@ -103,7 +103,7 @@ static zend_function_entry php_memcache_pool_class_functions[] = {
 	PHP_FALIAS(close,					memcache_close,						NULL)
 	PHP_FALIAS(flush,					memcache_flush,						NULL)
 	PHP_FALIAS(setSaslAuthData,			memcache_set_sasl_auth_data,				NULL)
-	
+
 	{NULL, NULL, NULL}
 };
 
@@ -292,14 +292,14 @@ PHP_INI_BEGIN()
 	STD_PHP_INI_ENTRY("memcache.session_redundancy",	"2",			PHP_INI_ALL, OnUpdateRedundancy,	session_redundancy,	zend_memcache_globals,	memcache_globals)
 	STD_PHP_INI_ENTRY("memcache.compress_threshold",	"20000",		PHP_INI_ALL, OnUpdateCompressThreshold,	compress_threshold,	zend_memcache_globals,	memcache_globals)
 	STD_PHP_INI_ENTRY("memcache.lock_timeout",			"15",			PHP_INI_ALL, OnUpdateLockTimeout,		lock_timeout,		zend_memcache_globals,	memcache_globals)
-	STD_PHP_INI_ENTRY("memcache.session_prefix_host_key",       			"0",			PHP_INI_ALL, OnUpdateBool, session_prefix_host_key, zend_memcache_globals, memcache_globals)
-	STD_PHP_INI_ENTRY("memcache.session_prefix_host_key_remove_www",    	"1",			PHP_INI_ALL, OnUpdateBool, session_prefix_host_key_remove_www, zend_memcache_globals, memcache_globals)
-	STD_PHP_INI_ENTRY("memcache.session_prefix_host_key_remove_subdomain",  "0",			PHP_INI_ALL, OnUpdateBool, session_prefix_host_key_remove_subdomain, zend_memcache_globals, memcache_globals)
+	STD_PHP_INI_BOOLEAN("memcache.session_prefix_host_key",       			"0",			PHP_INI_ALL, OnUpdateBool, session_prefix_host_key, zend_memcache_globals, memcache_globals)
+	STD_PHP_INI_BOOLEAN("memcache.session_prefix_host_key_remove_www",    	"1",			PHP_INI_ALL, OnUpdateBool, session_prefix_host_key_remove_www, zend_memcache_globals, memcache_globals)
+	STD_PHP_INI_BOOLEAN("memcache.session_prefix_host_key_remove_subdomain",  "0",			PHP_INI_ALL, OnUpdateBool, session_prefix_host_key_remove_subdomain, zend_memcache_globals, memcache_globals)
 	STD_PHP_INI_ENTRY("memcache.session_prefix_static_key",         		NULL,			PHP_INI_ALL, OnUpdatePrefixStaticKey, session_prefix_static_key, zend_memcache_globals, memcache_globals)
 	STD_PHP_INI_ENTRY("memcache.session_save_path",         				NULL,			PHP_INI_ALL, OnUpdateString, session_save_path, zend_memcache_globals, memcache_globals)
-	STD_PHP_INI_ENTRY("memcache.prefix_host_key",       					"0",			PHP_INI_ALL, OnUpdateBool, prefix_host_key, zend_memcache_globals, memcache_globals)
-	STD_PHP_INI_ENTRY("memcache.prefix_host_key_remove_www",    			"1",			PHP_INI_ALL, OnUpdateBool, prefix_host_key_remove_www, zend_memcache_globals, memcache_globals)
-	STD_PHP_INI_ENTRY("memcache.prefix_host_key_remove_subdomain",  		"0",			PHP_INI_ALL, OnUpdateBool, prefix_host_key_remove_subdomain, zend_memcache_globals, memcache_globals)
+	STD_PHP_INI_BOOLEAN("memcache.prefix_host_key",       					"0",			PHP_INI_ALL, OnUpdateBool, prefix_host_key, zend_memcache_globals, memcache_globals)
+	STD_PHP_INI_BOOLEAN("memcache.prefix_host_key_remove_www",    			"1",			PHP_INI_ALL, OnUpdateBool, prefix_host_key_remove_www, zend_memcache_globals, memcache_globals)
+	STD_PHP_INI_BOOLEAN("memcache.prefix_host_key_remove_subdomain",  		"0",			PHP_INI_ALL, OnUpdateBool, prefix_host_key_remove_subdomain, zend_memcache_globals, memcache_globals)
 	STD_PHP_INI_ENTRY("memcache.prefix_static_key",         				NULL,			PHP_INI_ALL, OnUpdatePrefixStaticKey, prefix_static_key, zend_memcache_globals, memcache_globals)
 PHP_INI_END()
 /* }}} */
@@ -878,7 +878,7 @@ static void php_mmc_numeric(INTERNAL_FUNCTION_PARAMETERS, int deleted, int inver
 	memcpy((char *)persistent_id, key, key_len+1);
 	if (zend_register_persistent_resource ( (char*) persistent_id, key_len, mmc, le_memcache_server) == NULL) ;
 
-	then not forget to pefree, check refcounts in _mmc_server_free / _mmc_server_list_dtor ,  etc. 
+	then not forget to pefree, check refcounts in _mmc_server_free / _mmc_server_list_dtor ,  etc.
 	otherwise we will leak mem with persistent connections /run into other trouble with later versions
 	*/
 mmc_t *mmc_find_persistent(const char *host, int host_len, unsigned short port, unsigned short udp_port, double timeout, int retry_interval) /* {{{ */

--- a/php7/memcache_pool.h
+++ b/php7/memcache_pool.h
@@ -47,7 +47,7 @@
 
 /*
  * Mac OS X has no MSG_NOSIGNAL but >= 10.2 comes with SO_NOSIGPIPE which is a setsockopt() option
- * and not a send() parameter as MSG_NOSIGNAL. OpenBSD has none of the options so we need to ignore 
+ * and not a send() parameter as MSG_NOSIGNAL. OpenBSD has none of the options so we need to ignore
  * SIGPIPE events
  */
 #ifndef MSG_NOSIGNAL
@@ -285,7 +285,7 @@ typedef struct mmc_protocol {
 	mmc_protocol_flush		flush;
 	mmc_protocol_version	version;
 	mmc_protocol_stats		stats;
-	
+
 	mmc_protocol_set_sasl_auth_data set_sasl_auth_data;
 } mmc_protocol_t;
 
@@ -415,15 +415,15 @@ ZEND_BEGIN_MODULE_GLOBALS(memcache)
 	long compress_threshold;
 	long lock_timeout;
 	char *session_key_prefix;
-	char *session_prefix_host_key;
-	char *session_prefix_host_key_remove_www;
-	char *session_prefix_host_key_remove_subdomain;
+	zend_bool session_prefix_host_key;
+	zend_bool session_prefix_host_key_remove_www;
+	zend_bool session_prefix_host_key_remove_subdomain;
 	char *session_prefix_static_key;
 	char *session_save_path;
 	char *key_prefix;
-	char *prefix_host_key;
-	char *prefix_host_key_remove_www;
-	char *prefix_host_key_remove_subdomain;
+	zend_bool prefix_host_key;
+	zend_bool prefix_host_key_remove_www;
+	zend_bool prefix_host_key_remove_subdomain;
 	char *prefix_static_key;
 ZEND_END_MODULE_GLOBALS(memcache)
 


### PR DESCRIPTION
I think that these might have uninitialized bytes
when a data type larger than zend_bool is used for the ini setting,
if the module globals are set from malloc?
(Not 100% sure if the entire structure isn't set to 0 before being used)

Related to #56