### PR TITLE
Explicitly disconnect from servers

### DIFF
--- a/src/memcache_pool.c
+++ b/src/memcache_pool.c
@@ -851,6 +851,9 @@ void mmc_server_free(mmc_t *mmc) /* {{{ */
 {
 	mmc_server_sleep(mmc);
 
+	_mmc_server_disconnect(mmc, &(mmc->tcp), 0);
+	_mmc_server_disconnect(mmc, &(mmc->udp), 0);
+
 	pefree(mmc->host, mmc->persistent);
 	pefree(mmc, mmc->persistent);
 }


### PR DESCRIPTION
Connections aren't closed correctly when `fork` is used to start new workers.

I've seen this [committed](https://github.com/websupport-sk/pecl-memcache/commit/8047d507d4ac9ffdf7e444e44bff495a0863cc30#diff-3404da3176487849198537c85f880275c5b14f65112a4fe976919e5a1eea823bR816) and then [reverted](https://github.com/websupport-sk/pecl-memcache/commit/4043142b9eeb582df2f557f71259b316d67e73ce#diff-3404da3176487849198537c85f880275c5b14f65112a4fe976919e5a1eea823bL816) on the same day in the past. I saw you've added the [`sleep` back](https://github.com/websupport-sk/pecl-memcache/pull/74/files#diff-a68b9c38916f216f604065075f92b20ccaa15316ad0a6b82834b3c5fed9a5504R833) which should work with persistent connections, but won't close non-persistent connections.

`memcached` also has this [problem](https://github.com/php-memcached-dev/php-memcached/issues/195#issuecomment-277999977), tho closed as `won't fix`. 