### PR TITLE
Memory corruption when server unreachable, and memcache_get() with multiple keys

### DIFF
--- a/src/memcache_pool.c
+++ b/src/memcache_pool.c
@@ -1544,7 +1544,7 @@ void mmc_pool_select(mmc_pool_t *pool) /*
 		}
 
 		if ( ! pool->sending->len && ( mmc->sendreq != NULL || mmc->sendqueue.len ) ) {
-			php_error_docref( NULL TSRMLS_CC, E_WARNING, "mmc_pool_select() failed to cleanup when sending! Sendqueue: %d", mmc->sendqueue.len );
+			php_error_docref( NULL, E_WARNING, "mmc_pool_select() failed to cleanup when sending! Sendqueue: %d", mmc->sendqueue.len );
 		}
 	}
 
@@ -1643,7 +1643,7 @@ void mmc_pool_select(mmc_pool_t *pool) /*
 								/* take server offline and failover requests */
 								mmc_server_deactivate(pool, mmc);
 							} else {
-								mmc_select_retry(pool, mmc, mmc->readreq TSRMLS_CC);
+								mmc_select_retry(pool, mmc, mmc->readreq);
 							}
 						}
 						break;
@@ -1668,7 +1668,7 @@ void mmc_pool_select(mmc_pool_t *pool) /*
 		}
 
 		if ( ! pool->reading->len && ( mmc->readreq != NULL || mmc->readqueue.len ) ) {
-			php_error_docref( NULL TSRMLS_CC, E_WARNING, "mmc_pool_select() failed to cleanup when reading! Readqueue: %d", mmc->readqueue.len );
+			php_error_docref( NULL, E_WARNING, "mmc_pool_select() failed to cleanup when reading! Readqueue: %d", mmc->readqueue.len );
 		}
 	}
 
@@ -1680,7 +1680,7 @@ void mmc_pool_schedule_pending(mmc_pool_t *pool) {
 	mmc_t *mmc;
 	while ((mmc = mmc_queue_pop(&(pool->pending))) != NULL) {
 		pool->protocol->end_get(mmc->buildreq);
-		mmc_pool_schedule(pool, mmc, mmc->buildreq TSRMLS_CC);
+		mmc_pool_schedule(pool, mmc, mmc->buildreq);
 		mmc->buildreq = NULL;
 	}
 }

--- a/src/memcache_pool.c
+++ b/src/memcache_pool.c
@@ -1542,6 +1542,10 @@ void mmc_pool_select(mmc_pool_t *pool) /*
 			/* add server to send queue once more */
 			mmc_queue_push(pool->sending, mmc);
 		}
+
+		if ( ! pool->sending->len && ( mmc->sendreq != NULL || mmc->sendqueue.len ) ) {
+			php_error_docref( NULL TSRMLS_CC, E_WARNING, "mmc_pool_select() failed to cleanup when sending! Sendqueue: %d", mmc->sendqueue.len );
+		}
 	}
 
 	for (i=0; i < reading->len; i++) {
@@ -1638,6 +1642,8 @@ void mmc_pool_select(mmc_pool_t *pool) /*
 							if (result == MMC_REQUEST_FAILURE) {
 								/* take server offline and failover requests */
 								mmc_server_deactivate(pool, mmc);
+							} else {
+								mmc_select_retry(pool, mmc, mmc->readreq TSRMLS_CC);
 							}
 						}
 						break;
@@ -1660,24 +1666,35 @@ void mmc_pool_select(mmc_pool_t *pool) /*
 			/* add server to read queue once more */
 			mmc_queue_push(pool->reading, mmc);
 		}
+
+		if ( ! pool->reading->len && ( mmc->readreq != NULL || mmc->readqueue.len ) ) {
+			php_error_docref( NULL TSRMLS_CC, E_WARNING, "mmc_pool_select() failed to cleanup when reading! Readqueue: %d", mmc->readqueue.len );
+		}
 	}
 
 	pool->in_select = 0;
 }
 /* }}} */
 
+void mmc_pool_schedule_pending(mmc_pool_t *pool) {
+	mmc_t *mmc;
+	while ((mmc = mmc_queue_pop(&(pool->pending))) != NULL) {
+		pool->protocol->end_get(mmc->buildreq);
+		mmc_pool_schedule(pool, mmc, mmc->buildreq TSRMLS_CC);
+		mmc->buildreq = NULL;
+	}
+}
+
 void mmc_pool_run(mmc_pool_t *pool)  /*
 	runs all scheduled requests to completion {{{ */
 {
 	mmc_t *mmc;
-	while ((mmc = mmc_queue_pop(&(pool->pending))) != NULL) {
-		pool->protocol->end_get(mmc->buildreq);
-		mmc_pool_schedule(pool, mmc, mmc->buildreq);
-		mmc->buildreq = NULL;
-	}
+
+	mmc_pool_schedule_pending(pool);
 
 	while (pool->reading->len || pool->sending->len) {
 		mmc_pool_select(pool);
+		mmc_pool_schedule_pending(pool);
 	}
 }
 /* }}} */


### PR DESCRIPTION
`mmc_pool_select` change:
The problem was that memcache.so will execute “get()s” when “set()s” are
requested and vice versa. This would happen because in certain cases of
Memcached failures, instead of retrying failed requests memcache.so will
just forget about them and move on to the next request, while leaving
the state of the old request uncleaned. Then when a new request comes,
memcache.so will retry the previously failed request which already has
many of it’s pointers free()d and thus the segfaults.

`mmc_pool_run` changes:
Executing memcache_get()s with multiple keys were not retried properly
and left for the next request, where they segfaulted.
