### PR TITLE
Fix version string and remove revision

### DIFF
--- a/src/memcache.c
+++ b/src/memcache.c
@@ -780,7 +780,6 @@ PHP_MINFO_FUNCTION(memcache)
 	php_info_print_table_start();
 	php_info_print_table_header(2, "memcache support", "enabled");
 	php_info_print_table_row(2, "Version", PHP_MEMCACHE_VERSION);
-	php_info_print_table_row(2, "Revision", "$Revision$");
 	php_info_print_table_end();
 
 	DISPLAY_INI_ENTRIES();

--- a/src/php_memcache.h
+++ b/src/php_memcache.h
@@ -67,7 +67,7 @@ PHP_FUNCTION(memcache_close);
 PHP_FUNCTION(memcache_flush);
 PHP_FUNCTION(memcache_set_sasl_auth_data);
 
-#define PHP_MEMCACHE_VERSION "8.0"
+#define PHP_MEMCACHE_VERSION "8.1-dev"
 
 #define MMC_DEFAULT_TIMEOUT 1				/* seconds */
 #define MMC_DEFAULT_RETRY 15 				/* retry failed server after x seconds */

--- a/src/php_memcache.h
+++ b/src/php_memcache.h
@@ -67,7 +67,7 @@ PHP_FUNCTION(memcache_close);
 PHP_FUNCTION(memcache_flush);
 PHP_FUNCTION(memcache_set_sasl_auth_data);
 
-#define PHP_MEMCACHE_VERSION "4.0.5.2"
+#define PHP_MEMCACHE_VERSION "8.0"
 
 #define MMC_DEFAULT_TIMEOUT 1				/* seconds */
 #define MMC_DEFAULT_RETRY 15 				/* retry failed server after x seconds */


### PR DESCRIPTION
Not clean the reason behind `$Revision$` is it supposed to be replacable on packaging?

That's mostly from #80 and https://github.com/websupport-sk/pecl-memcache/issues/79#issuecomment-739538188