### PR TITLE
docs: fix simple typo, immediatly -> immediately

### DIFF
--- a/src/memcache.c
+++ b/src/memcache.c
@@ -924,7 +924,7 @@ static void php_mmc_store(INTERNAL_FUNCTION_PARAMETERS, int op) /* {{{ */
 				continue;
 			}
 
-			/* begin sending requests immediatly */
+			/* begin sending requests immediately */
 			mmc_pool_select(pool);
 		} ZEND_HASH_FOREACH_END();
 	}
@@ -1089,7 +1089,7 @@ static void php_mmc_numeric(INTERNAL_FUNCTION_PARAMETERS, int deleted, int inver
 				continue;
 			}
 
-			/* begin sending requests immediatly */
+			/* begin sending requests immediately */
 			mmc_pool_select(pool);
 		} ZEND_HASH_FOREACH_END();
 
@@ -2492,7 +2492,7 @@ PHP_FUNCTION(memcache_flush)
 		pool->protocol->flush(request, delay);
 
 		if (mmc_pool_schedule(pool, pool->servers[i], request) == MMC_OK) {
-			/* begin sending requests immediatly */
+			/* begin sending requests immediately */
 			mmc_pool_select(pool);
 		}
 	}

--- a/src/memcache_pool.c
+++ b/src/memcache_pool.c
@@ -1303,7 +1303,7 @@ int mmc_pool_schedule_get(
 		pool->protocol->end_get(mmc->buildreq);
 		mmc_pool_schedule(pool, mmc, mmc->buildreq);
 
-		/* begin sending requests immediatly */
+		/* begin sending requests immediately */
 		mmc_pool_select(pool);
 
 		mmc->buildreq = mmc_pool_request_get(


### PR DESCRIPTION
There is a small typo in src/memcache.c, src/memcache_pool.c.

Should read `immediately` rather than `immediatly`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md