### PR TITLE
Clarify v4.x installation for php 7.x docs

### DIFF
--- a/README
+++ b/README
@@ -5,7 +5,7 @@ which was originally developed for the need of hosting company in Slovakia (Webs
 
 The latest release is 8.0 (released: 2020-12-06) with support for PHP 8.0.
 
-Please use version 4.0.5.1 (released: 2020-12-19) for PHP 7.x from branch NON_BLOCKING_IO_php7.
+Please use latest version 4.x for PHP 7.x from branch NON_BLOCKING_IO_php7.
 
 See: https://github.com/websupport-sk/pecl-memcache/releases
 See also release on PECL: https://pecl.php.net/package/memcache


### PR DESCRIPTION
Since I also faced the issue https://github.com/websupport-sk/pecl-memcache/issues/60 with PHP 7.4.
This PR **just** clarify the v4.x installation docs for PHP 7.x on default branch's README according to https://pecl.php.net/package/memcache/4.0.5.2. Because the indicated v4.0.5.1 breaks my builds (but fixed by v4.0.5.2).

