### PR TITLE
win32/php_stdint.h is removed as of PHP 8.0.0

### DIFF
--- a/src/memcache_binary_protocol.c
+++ b/src/memcache_binary_protocol.c
@@ -25,11 +25,10 @@
 
 #define MMC_DEBUG 0
 
+#include <stdint.h>
 #ifdef PHP_WIN32
-#include <win32/php_stdint.h>
 #include <winsock2.h>
 #else
-#include <stdint.h>
 #include <arpa/inet.h>
 #include <netinet/in.h>
 #endif

--- a/src/memcache_pool.h
+++ b/src/memcache_pool.h
@@ -34,11 +34,7 @@
 #include <sys/socket.h>
 #endif
 
-#ifdef PHP_WIN32
-#include <win32/php_stdint.h>
-#else
 #include <stdint.h>
-#endif
 #include <string.h>
 
 #include "php.h"


### PR DESCRIPTION
Cf. <https://github.com/php/php-src/pull/5323>.