### PR TITLE
Test and fix memcache session redundancy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,13 @@
-ARG PHP_IMAGE=php:7.4-rc
+ARG PHP_IMAGE=php:7.4
 FROM $PHP_IMAGE
+
+RUN docker-php-ext-configure pcntl --enable-pcntl \
+    && docker-php-ext-install -j$(nproc) pcntl
 
 RUN apt-get update && apt-get install -y \ 
 	git \
 	zlib1g-dev \
-	memcached ; 
+	memcached ;
 
 COPY docker/host.conf /etc/host.conf
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,17 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+VAGRANTFILE_API_VERSION = '2'
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+    config.vm.box = 'ubuntu/bionic64'
+
+    config.vm.provider :virtualbox do |vb|
+        vb.name = 'ext-memcache-dev'
+        vb.memory = 1024
+        vb.cpus = 2
+    end
+
+    config.vm.provision 'docker'
+
+end

--- a/php7/memcache_session.c
+++ b/php7/memcache_session.c
@@ -317,7 +317,7 @@ PS_READ_FUNC(memcache)
 			ZVAL_NULL(&addresult);
 
 			/* third request fetches the data, data is only valid if either of the lock requests succeeded */
-			ZVAL_EMPTY_STRING(&dataresult);
+			ZVAL_NULL(&dataresult);
 
 			/* create requests */
 			if (php_mmc_session_read_request(pool, &zkey, lockparam, &addresult, dataparam, &lockrequest, &addrequest, &datarequest) != MMC_OK) {

--- a/tests/redundancy_test.phpt
+++ b/tests/redundancy_test.phpt
@@ -1,0 +1,75 @@
+--TEST--
+redundancy test
+--SKIPIF--
+<?php include 'connect.inc'; if (!MEMCACHE_HAVE_SESSION) print 'skip not compiled with session support'; else if (!function_exists('pcntl_fork')) print 'skip not compiled with pcntl_fork() support'; ?>
+--FILE--
+<?php
+
+include 'connect.inc';
+
+$sid = md5(rand());
+
+ini_set('session.save_handler', 'memcache');
+ini_set('memcache.session_save_path', "tcp://$host:$port,tcp://$host2:$port2");
+ini_set('memcache.session_redundancy', 3);
+
+$memcache1 = test_connect1();
+$memcache2 = test_connect2();
+
+$pid = pcntl_fork();
+if (!$pid) {
+    // In child process
+    session_id($sid);
+    session_start();
+    if (!isset($_SESSION['counter']))
+        $_SESSION['counter'] = 0;
+    $_SESSION['counter'] += 1;
+    session_write_close();
+
+    exit(0);
+}
+pcntl_waitpid($pid, $status);
+
+$memcache1->flush();
+
+$pid = pcntl_fork();
+if (!$pid) {
+    // In child process
+    session_id($sid);
+    session_start();
+    if (!isset($_SESSION['counter']))
+        $_SESSION['counter'] = 0;
+    $_SESSION['counter'] += 1;
+    session_write_close();
+
+    exit(0);
+}
+pcntl_waitpid($pid, $status);
+
+$memcache2->flush();
+
+$pid = pcntl_fork();
+if (!$pid) {
+    // In child process
+    session_id($sid);
+    session_start();
+    if (!isset($_SESSION['counter']))
+        $_SESSION['counter'] = 0;
+    $_SESSION['counter'] += 1;
+    session_write_close();
+
+    exit(0);
+}
+pcntl_waitpid($pid, $status);
+
+
+session_id($sid);
+session_start();
+var_dump($_SESSION);
+
+?>
+--EXPECT--
+array(1) {
+  ["counter"]=>
+  int(3)
+}


### PR DESCRIPTION
This fixes the issue https://github.com/websupport-sk/pecl-memcache/issues/85

This basically reverts the commit https://github.com/websupport-sk/pecl-memcache/commit/4a9e4ab0d12150805feca3012854de9fd4e5a721 done by @remicollet  as suggested by @Roze.

The solution for the issue https://github.com/websupport-sk/pecl-memcache/issues/23 was not a good one on the long run.

The problem was that `dataresult` was an empty string, even when the key was not found so a fallback to the next server was not done.

I tried to replicate the original issue reported there with scripts from @ramsey but the problem is not present anymore and I'm not sure what fixed it.

Also, a test exists but from what I can see, it's not running in the pipeline yet and I'm not sure what is the best approach to have the pcntl extension during running the test. Help would be appreciated here