### PR TITLE
Fix  Deprecated: memcache_connect(): Passing null to parameter #2...

### DIFF
--- a/src/memcache.c
+++ b/src/memcache.c
@@ -1319,8 +1319,9 @@ static void php_mmc_connect(INTERNAL_FUNCTION_PARAMETERS, zend_bool persistent) 
 	size_t host_len;
 	zend_long tcp_port = MEMCACHE_G(default_port);
 	double timeout = MMC_DEFAULT_TIMEOUT;
+	zend_bool null_port;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s|ld", &host, &host_len, &tcp_port, &timeout) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s|l!d", &host, &host_len, &tcp_port, &null_port, &timeout) == FAILURE) {
 		return;
 	}
 


### PR DESCRIPTION
Using PHP 8.1.0alpha1

```
TEST 44/87 [tests/035.phpt]
========DIFF========
     bool(true)
     bool(true)
     string(3) "abc"
005+ 
006+ Deprecated: memcache_connect(): Passing null to parameter #2 ($port) of type int is deprecated in /work/GIT/pecl-and-ext/memcache/tests/035.php on line 18
     bool(true)
========DONE========
FAIL memcache::connect() with unix domain socket [tests/035.phpt] 

```


With this patch

```
=====================================================================
TEST RESULT SUMMARY
---------------------------------------------------------------------
Exts skipped    :    0
Exts tested     :   63
---------------------------------------------------------------------

Number of tests :   87                78
Tests skipped   :    9 ( 10.3%) --------
Tests warned    :    0 (  0.0%) (  0.0%)
Tests failed    :    0 (  0.0%) (  0.0%)
Tests passed    :   78 ( 89.7%) (100.0%)
---------------------------------------------------------------------
Time taken      :   13 seconds
=====================================================================

```