### PR TITLE
Memory corruption in mmc_flush_handler

### DIFF
--- a/src/memcache.c
+++ b/src/memcache.c
@@ -2449,7 +2449,6 @@ static int mmc_flush_handler(mmc_t *mmc, mmc_request_t *request, int response, c
 	}
 
 	if (response == MMC_RESPONSE_CLIENT_ERROR) {
-		ZVAL_FALSE((zval *)param);
 		php_error_docref(NULL, E_NOTICE,
 				"Server %s (tcp %d, udp %d) failed with: %s (%d)",
 				mmc->host, mmc->tcp.port,


### PR DESCRIPTION
In mmc_flush_handler the return param is a pointer to integer and ZVAL_FALSE should not be used as it results in memory corruption. The failure case is not supposed to modify the return param.

The problem can be reproduced by disabling flush_all in the Memcached server.