### PR TITLE
Descriptors equal or higher than FD_SETSIZE can't be used with select()

### DIFF
--- a/src/memcache_pool.c
+++ b/src/memcache_pool.c
@@ -770,6 +770,9 @@ static int mmc_server_connect(mmc_pool_t *pool, mmc_t *mmc, mmc_stream_t *io, in
 
 		return MMC_REQUEST_FAILURE;
 	}
+	if (fd >= FD_SETSIZE) {
+		php_error_docref(NULL, E_ERROR, "Too many open file descriptors: %d", fd);
+	}
 	php_stream_auto_cleanup(io->stream);
 	php_stream_set_chunk_size(io->stream, io->chunk_size);
 	php_stream_set_option(io->stream, PHP_STREAM_OPTION_BLOCKING, 0, NULL);


### PR DESCRIPTION
As per select(2) manual page: Executing FD_CLR() or FD_SET() with a value of fd that is negative or is equal to or larger than FD_SETSIZE  will result in undefined behavior.

If we don't check whether the file descriptor is less than FD_SETSIZE it's easy to trigger segfaults in the extension. This is easy to reproduce with the following script:

```
<?php

for ( $i = 0; $i < 1024; $i++ ) {
    socket_create_pair(AF_UNIX, SOCK_STREAM, 0, $socketpair);
    $sockets[] = $socketpair;
}

memcache_get(memcache_connect('memcache_host, 11211), 'some_key');
```

Long term the extension should probably be switched to a different polling API, but in the short term this patch will trigger Fatal Errors when we run out of allowed file descriptors so that segfaults are not generated.