### PR TITLE
fix "*** buffer overflow detected ***: terminated Aborted" by adding posix poll() io implementation in addition to select()

### DIFF
--- a/src/memcache.c
+++ b/src/memcache.c
@@ -523,6 +523,33 @@ static PHP_INI_MH(OnUpdateLockTimeout) /* {{{ */
 }
 /* }}} */
 
+static PHP_INI_MH(OnUpdateSelectApi) /* {{{ */
+{
+	#ifdef PHP_WIN32
+	if (!strcasecmp(ZSTR_VAL(new_value), "select")) {
+		MEMCACHE_G(select_api) = MMC_API_SELECT;
+	}
+	else {
+		php_error_docref(NULL, E_WARNING, "memcache.select_api supports only 'select' on Windows ('%s' given)", ZSTR_VAL(new_value));
+		return FAILURE;
+	}
+	#else
+	if (!strcasecmp(ZSTR_VAL(new_value), "select")) {
+		MEMCACHE_G(select_api) = MMC_API_SELECT;
+	}
+	else if (!strcasecmp(ZSTR_VAL(new_value), "poll")) {
+		MEMCACHE_G(select_api) = MMC_API_POLL;
+	}
+	else {
+		php_error_docref(NULL, E_WARNING, "memcache.select_api must be in set {select, poll} ('%s' given)", ZSTR_VAL(new_value));
+		return FAILURE;
+	}
+	#endif
+
+	return SUCCESS;
+}
+/* }}} */
+
 static PHP_INI_MH(OnUpdatePrefixStaticKey) /* {{{ */
 {
 	int i;
@@ -553,6 +580,7 @@ PHP_INI_BEGIN()
 	STD_PHP_INI_ENTRY("memcache.session_redundancy",	"2",			PHP_INI_ALL, OnUpdateRedundancy,	session_redundancy,	zend_memcache_globals,	memcache_globals)
 	STD_PHP_INI_ENTRY("memcache.compress_threshold",	"20000",		PHP_INI_ALL, OnUpdateCompressThreshold,	compress_threshold,	zend_memcache_globals,	memcache_globals)
 	STD_PHP_INI_ENTRY("memcache.lock_timeout",			"15",			PHP_INI_ALL, OnUpdateLockTimeout,		lock_timeout,		zend_memcache_globals,	memcache_globals)
+	STD_PHP_INI_ENTRY("memcache.select_api",			"select",		PHP_INI_ALL, OnUpdateSelectApi,		select_api,		zend_memcache_globals,	memcache_globals)
 	STD_PHP_INI_BOOLEAN("memcache.session_prefix_host_key",       			"0",			PHP_INI_ALL, OnUpdateBool, session_prefix_host_key, zend_memcache_globals, memcache_globals)
 	STD_PHP_INI_BOOLEAN("memcache.session_prefix_host_key_remove_www",    	"1",			PHP_INI_ALL, OnUpdateBool, session_prefix_host_key_remove_www, zend_memcache_globals, memcache_globals)
 	STD_PHP_INI_BOOLEAN("memcache.session_prefix_host_key_remove_subdomain",  "0",			PHP_INI_ALL, OnUpdateBool, session_prefix_host_key_remove_subdomain, zend_memcache_globals, memcache_globals)
@@ -578,6 +606,7 @@ static void php_memcache_init_globals(zend_memcache_globals *memcache_globals_p)
 {
 	MEMCACHE_G(hash_strategy)	  = MMC_STANDARD_HASH;
 	MEMCACHE_G(hash_function)	  = MMC_HASH_CRC32;
+	MEMCACHE_G(select_api)        = MMC_API_SELECT;
 }
 /* }}} */
 

--- a/src/memcache_pool.h
+++ b/src/memcache_pool.h
@@ -115,6 +115,9 @@
 #define MMC_HASH_CRC32 			1			/* CRC32 hash function */
 #define MMC_HASH_FNV1A 			2			/* FNV-1a hash function */
 
+#define MMC_API_SELECT 		1
+#define MMC_API_POLL 		2
+
 #define MMC_CONSISTENT_POINTS	160			/* points per server */
 #define MMC_CONSISTENT_BUCKETS	1024		/* number of precomputed buckets, should be power of 2 */
 
@@ -339,6 +342,11 @@ struct mmc_pool {
 	void					*hash_state;				/* strategy specific state */
 	fd_set					wfds;
 	fd_set					rfds;
+	#ifndef PHP_WIN32
+	struct pollfd			*pollfds;
+	int						nfds;
+	#endif
+	long 					select_api;
 	struct timeval			timeout;					/* smallest timeout for any of the servers */
 	int						in_select;
 	mmc_queue_t				*sending;					/* mmc_queue_t<mmc_t *>, connections that want to send */
@@ -414,6 +422,7 @@ ZEND_BEGIN_MODULE_GLOBALS(memcache)
 	long session_redundancy;
 	long compress_threshold;
 	long lock_timeout;
+	long select_api;
 	char *session_key_prefix;
 	zend_bool session_prefix_host_key;
 	zend_bool session_prefix_host_key_remove_www;


### PR DESCRIPTION
select() API has a major drawback which doesn't allow to work with fd numbers bigger than 1024. It's a really small number nowadays as the fd table is shared between open files, sockets, connections and so on. While it might be ok for small projects it is critical for high-load projects with a lot of connections open simultaneously or for projects which work with a lot of files dealing with memcache at the same time.

Here's a quote from from first lines of documentation for select():

> WARNING: select() can monitor only file descriptors numbers that
>        are less than FD_SETSIZE (1024)—an unreasonably low limit for
>        many modern applications—and this limitation will not change.
>        All modern applications should instead use [poll(2)](https://man7.org/linux/man-pages/man2/poll.2.html) or [epoll(7)](https://man7.org/linux/man-pages/man7/epoll.7.html),
>        which do not suffer this limitation.

https://man7.org/linux/man-pages/man2/select.2.html

Here's a reproduce case:

```
<?php
for ($i = 0; $i < 1024; $i++) {
        $f[] = fopen("/tmp/testfd_$i", 'a'); // the same effect with files, sockets, open connections, etc
}

$m = memcache_connect('localhost');
if ($m !== false) {
	$a = memcache_get($m, 'key');
}
```

here's result:
```
php -f 1.php
*** buffer overflow detected ***: terminated
Aborted (core dumped)
```

The PR adds option _memcache.select_api_ which is one of _poll_ or _select_ (default). On Win32 only _select_ is supported for now. While it is technically possible to implement it for win32 as it should be available starting from Windows Vista I left it for further scope as I don't have relevant expertise working with Windows APIs.