### PR TITLE
Compatibility with PHP 8.2

### DIFF
--- a/src/memcache.c
+++ b/src/memcache.c
@@ -752,6 +752,18 @@ PHP_MINIT_FUNCTION(memcache)
 	zend_declare_typed_property(memcache_ce, property_failure_callback_name, &property_failure_callback_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_CALLABLE|MAY_BE_NULL));
 	zend_string_release(property_failure_callback_name);
 
+	zval property_username_default_value;
+	ZVAL_NULL(&property_username_default_value);
+	zend_string *property_username_name = zend_string_init("username", sizeof("username") - 1, 1);
+	zend_declare_typed_property(memcache_ce, property_username_name, &property_username_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
+	zend_string_release(property_username_name);
+
+	zval property_password_default_value;
+	ZVAL_NULL(&property_password_default_value);
+	zend_string *property_password_name = zend_string_init("password", sizeof("password") - 1, 1);
+	zend_declare_typed_property(memcache_ce, property_password_name, &property_password_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
+	zend_string_release(property_password_name);
+
 	le_memcache_pool = zend_register_list_destructors_ex(_mmc_pool_list_dtor, NULL, "memcache connection", module_number);
 	le_memcache_server = zend_register_list_destructors_ex(NULL, _mmc_server_list_dtor, "persistent memcache connection", module_number);
 

--- a/tests/017.phpt
+++ b/tests/017.phpt
@@ -26,5 +26,7 @@ foo
 object(test)%s%d) {
   ["connection"]=>
   resource(%d) of type (memcache connection)
+  ["_failureCallback":"Memcache":private]=>
+  NULL
 }
 Done

--- a/tests/017.phpt
+++ b/tests/017.phpt
@@ -28,5 +28,9 @@ object(test)%s%d) {
   resource(%d) of type (memcache connection)
   ["_failureCallback":"Memcache":private]=>
   NULL
+  ["username"]=>
+  NULL
+  ["password"]=>
+  NULL
 }
 Done

--- a/tests/029.phpt
+++ b/tests/029.phpt
@@ -44,7 +44,8 @@ if (is_array($result))
 	sort($result);
 var_dump($result);
 
-$result = ini_set('memcache.allow_failover', "abc");
+// @ is to prevent warning on 8.2
+$result = @ini_set('memcache.allow_failover', "abc");
 var_dump($result);
 
 ?>

--- a/tests/045.phpt
+++ b/tests/045.phpt
@@ -8,6 +8,8 @@ Nested get's in __wakeup()
 include 'connect.inc';
 
 class testclass {
+    public $result;
+
 	function __wakeup() {
 		global $memcache;
 		$this->result = $memcache->get('_test_key3');

--- a/tests/059.phpt
+++ b/tests/059.phpt
@@ -302,7 +302,9 @@ Class [ <internal:memcache> class Memcache extends MemcachePool ] {
   - Static methods [0] {
   }
 
-  - Properties [0] {
+  - Properties [2] {
+    Property [ public mixed $connection = NULL ]
+    Property [ private ?callable $_failureCallback = NULL ]
   }
 
   - Methods [24] {

--- a/tests/059.phpt
+++ b/tests/059.phpt
@@ -302,9 +302,11 @@ Class [ <internal:memcache> class Memcache extends MemcachePool ] {
   - Static methods [0] {
   }
 
-  - Properties [2] {
+  - Properties [4] {
     Property [ public mixed $connection = NULL ]
     Property [ private ?callable $_failureCallback = NULL ]
+    Property [ public ?string $username = NULL ]
+    Property [ public ?string $password = NULL ]
   }
 
   - Methods [24] {

--- a/tests/101.phpt
+++ b/tests/101.phpt
@@ -1,0 +1,23 @@
+--TEST--
+memcache->setSaslAuthData() and memcache_set_sasl_auth_data()
+--SKIPIF--
+<?php include 'connect.inc'; ?>
+--FILE--
+<?php
+include 'connect.inc';
+
+$memcache->setSaslAuthData('testuser1', 'testpassword1');
+
+var_dump($memcache->username);
+var_dump($memcache->password);
+
+memcache_set_sasl_auth_data($memcache, 'testuser2', 'testpassword2');
+
+var_dump($memcache->username);
+var_dump($memcache->password);
+
+--EXPECTF--
+string(9) "testuser1"
+string(13) "testpassword1"
+string(9) "testuser2"
+string(13) "testpassword2"


### PR DESCRIPTION
Most of issues with PHP 8.2 are caused by [dynamic properties deprecations ](https://wiki.php.net/rfc/deprecate_dynamic_properties)

So in order to resolve the issues I explicitly declared 2 properties in _Memcache_ class. In the future it is possible to add type hint to _connection_ property but it would break BC. (there is even a test which check if _connection_ is possible to set to _true_)

Also there were some minor incompatibilities in tests which were fixed.  

I checked on PHP 8.2.0RC1.

Before the patch:

```
> =====================================================================
> TEST RESULT SUMMARY
> ---------------------------------------------------------------------
> Exts skipped    :    0
> Exts tested     :   27
> ---------------------------------------------------------------------
> 
> Number of tests :   87                 1
> Tests borked    :   79 ( 90.8%) --------
> Tests skipped   :    7 (  8.0%) --------
> Tests warned    :    0 (  0.0%) (  0.0%)
> Tests failed    :    0 (  0.0%) (  0.0%)
> Tests passed    :    1 (  1.1%) (100.0%)
> ---------------------------------------------------------------------
> Time taken      :    0 seconds
> =====================================================================
```


With this patch:

```
> =====================================================================
> TEST RESULT SUMMARY
> ---------------------------------------------------------------------
> Exts skipped    :    0
> Exts tested     :   26
> ---------------------------------------------------------------------
> 
> Number of tests :   87                76
> Tests skipped   :   11 ( 12.6%) --------
> Tests warned    :    0 (  0.0%) (  0.0%)
> Tests failed    :    0 (  0.0%) (  0.0%)
> Tests passed    :   76 ( 87.4%) (100.0%)
> ---------------------------------------------------------------------
> Time taken      :    5 seconds
> =====================================================================
```
