### PR TITLE
trivial/minimal fix for PHP 8.2

### DIFF
--- a/src/memcache.c
+++ b/src/memcache.c
@@ -733,9 +733,15 @@ PHP_MINIT_FUNCTION(memcache)
 
 	INIT_CLASS_ENTRY(ce, "MemcachePool", php_memcache_pool_class_functions);
 	memcache_pool_ce = zend_register_internal_class(&ce);
+#if PHP_VERSION_ID >= 80200
+	memcache_pool_ce->ce_flags |= ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES;
+#endif
 
 	INIT_CLASS_ENTRY(ce, "Memcache", php_memcache_class_functions);
 	memcache_ce = zend_register_internal_class_ex(&ce, memcache_pool_ce);
+#if PHP_VERSION_ID >= 80200
+	memcache_ce->ce_flags |= ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES;
+#endif
 
 	le_memcache_pool = zend_register_list_destructors_ex(_mmc_pool_list_dtor, NULL, "memcache connection", module_number);
 	le_memcache_server = zend_register_list_destructors_ex(NULL, _mmc_server_list_dtor, "persistent memcache connection", module_number);

--- a/tests/029.phpt
+++ b/tests/029.phpt
@@ -44,7 +44,7 @@ if (is_array($result))
 	sort($result);
 var_dump($result);
 
-$result = ini_set('memcache.allow_failover', "abc");
+$result = @ini_set('memcache.allow_failover', "abc");
 var_dump($result);
 
 ?>

--- a/tests/045.phpt
+++ b/tests/045.phpt
@@ -8,6 +8,8 @@ Nested get's in __wakeup()
 include 'connect.inc';
 
 class testclass {
+	public $result = null;
+
 	function __wakeup() {
 		global $memcache;
 		$this->result = $memcache->get('_test_key3');


### PR DESCRIPTION
Alternative solution is to declare each used property (connection, username, password, _filaureCallback...)