### PR TITLE
[Windows] Fix PHP 8+ compatibility

### DIFF
--- a/src/memcache_binary_protocol.c
+++ b/src/memcache_binary_protocol.c
@@ -26,12 +26,16 @@
 #define MMC_DEBUG 0
 
 #ifdef PHP_WIN32
-#include <win32/php_stdint.h>
-#include <winsock2.h>
+# if defined(_MSC_VER) && _MSC_VER < 1920
+#  include "win32/php_stdint.h"
+# else
+#  include <stdint.h>
+# endif
+# include <winsock2.h>
 #else
-#include <stdint.h>
-#include <arpa/inet.h>
-#include <netinet/in.h>
+# include <stdint.h>
+# include <arpa/inet.h>
+# include <netinet/in.h>
 #endif
 #include "memcache_pool.h"
 #include "ext/standard/php_smart_string.h"

--- a/src/memcache_pool.h
+++ b/src/memcache_pool.h
@@ -35,9 +35,13 @@
 #endif
 
 #ifdef PHP_WIN32
-#include <win32/php_stdint.h>
+# if defined(_MSC_VER) && _MSC_VER < 1920
+#  include "win32/php_stdint.h"
+# else
+#  include <stdint.h>
+# endif
 #else
-#include <stdint.h>
+# include <stdint.h>
 #endif
 #include <string.h>
 


### PR DESCRIPTION
Use stdint.h for PHP 8.0, 8.1, 8.2 et cetera. Otherwise keep using win32/php_stdint,h
Added some indentation to clarify the if/else/endif construction

_MSC_VER 1920 = Visual Studio 2019 version 16.0.0 or VS16, which is used for PHP8 on Windows.